### PR TITLE
Better failing, falsy values, 'ignore' option.

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,3 +1,4 @@
+
 { "excludeFiles":
   [ "**/node_modules/**"
   , "coverage"
@@ -8,7 +9,7 @@
 , "requireMultipleVarDecl": true
 , "disallowEmptyBlocks": true
 , "disallowSpaceAfterObjectKeys": true
-, "disallowCommaBeforeLineBreak": true
+, "disallowCommaBeforeLineBreak": false
 , "disallowTrailingWhitespace": true
 , "requireCapitalizedConstructors": true
 , "requireSpacesInsideObjectBrackets": "all"
@@ -17,8 +18,6 @@
 , "requireSpaceBeforeBinaryOperators": [ "+", "-", "/", "*", "=", "==", "===", "!=", "!==" ]
 , "requireSpaceAfterBinaryOperators": [ "+", "-", "/", "*", "=", "==", "===", "!=", "!==" ]
 , "requireSpaceAfterKeywords": [ "if", "else", "for", "while", "do", "switch", "try", "catch" ]
-, "disallowLeftStickedOperators": [ "?", "/", "*", "=", "==", "===", "!=", "!==", ">", ">=", "<", "<=" ]
-, "disallowRightStickedOperators": [ "?", "+", "/", "*", ":", "=", "==", "===", "!=", "!==", ">", ">=", "<", "<=" ]
 , "disallowSpaceAfterPrefixUnaryOperators": [ "++", "--", "+", "-", "~", "!" ]
 , "disallowSpaceBeforePostfixUnaryOperators": [ "++", "--" ]
 , "requireSpaceBeforeBinaryOperators": [ "+", "-", "/", "*", "=", "==", "===", "!=", "!==" ]

--- a/README.md
+++ b/README.md
@@ -16,14 +16,19 @@ var create2dArray = require('2d-array')
 
 console.log(create2dArray([ 1, 2, 3, 4, 5, 6 ], 2))
 // -> [ [ 1, 2 ], [ 3, 4 ], [ 5, 6 ] ]
+
+console.log(create2dArray([ 1, 2, 3, 4], 2, 2))
+// -> [ [ 1 ], [ 2, 3 ] ]
 ```
 
-### `var array = create2dArray(array, n)`
+### `var array = create2dArray(array, n[, ignore])`
 
 Options must include:
 
-- `array` - an array to transform into a 2d array
-- `n` - the number of items to be inside each array
+- `array` - an array to transform into a 2d array.
+- `n` - the number of items to be inside each array. Non-numbers (undefined, null, ''), Non-floats or strings that represent anything other than one number will return an empty array.
+- 'ignore' - Optional - When set, deletes the value specified from any array containing that value.
 
 ## Credits
-[Dom Harrington](https://github.com/domharrington/)
+* [Dom Harrington](https://github.com/domharrington/)
+* [Tyler Brothers](https://github.com/possibly/)

--- a/example.js
+++ b/example.js
@@ -2,3 +2,6 @@ var create2dArray = require('./')
 
 console.log(create2dArray([ 1, 2, 3, 4, 5, 6 ], 2))
 // -> [ [ 1, 2 ], [ 3, 4 ], [ 5, 6 ] ]
+
+console.log(create2dArray([ 1, 2, 3, 4 ], 2, 2))
+// -> [ [ 1 ], [ 3, 4 ] ]

--- a/index.js
+++ b/index.js
@@ -1,12 +1,25 @@
 module.exports = create2dArray
 
-function create2dArray(array, n) {
+function create2dArray(array, n, ignore) {
   var newArray = []
-    , input = array.slice(0)
+    , input = array.slice(0);
 
-  while (input[0]) {
+  while (input.length !== 0 && _isNumber(n)) {
     newArray.push(input.splice(0, n));
   }
 
+  if ( arguments.length > 2 ){ //ignore is set.
+    newArray.forEach( function(array, index) {
+      array = array.filter( function(x) {
+        return x !== ignore;
+      });
+      newArray[index] = array;
+    });
+  }
+
   return newArray;
+}
+
+function _isNumber(n){
+  return !isNaN(parseFloat(n)) && isFinite(n);
 }

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
   "author": "Dom Harrington <dom@harrington-mail.com>",
   "license": "ISC",
   "devDependencies": {
-    "mocha": "^1.18.2",
-    "istanbul": "^0.2.7",
-    "jshint": "^2.5.0",
-    "jscs": "^1.4.5"
+    "istanbul": "^0.3.22",
+    "jscs": "^2.3.0",
+    "jshint": "^2.8.0",
+    "mocha": "^2.3.3"
   },
   "repository": {
     "type": "git",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -13,4 +13,34 @@ describe('2d-array', function () {
 
   })
 
+  it('should transform a 1d array with falsy values into a 2d array', function() {
+
+    assert.deepEqual(create2dArray([ 0, undefined, null, false, '' ], 2)
+      , [ [ 0, undefined ], [ null, false ], [ '' ] ])
+
+  })
+
+  it('should allow set values to be ignored', function() {
+
+    assert.deepEqual(create2dArray([ 0, undefined, 3, 'skipme', 4 ], 2, 'skipme')
+      , [ [ 0, undefined ], [ 3 ], [ 4 ] ])
+
+  })
+
+  it('should return an empty array when n is not a number', function() {
+
+    assert.deepEqual(create2dArray([ 0, undefined, 3, 4 ], '')
+      , [ ])
+
+    assert.deepEqual(create2dArray([ 0, undefined, 3, 4 ], undefined)
+      , [ ])
+
+    assert.deepEqual(create2dArray([ 1, 2, 3, 4 ], '4') //strings still work though
+      , [ [ 1, 2, 3, 4 ] ])
+
+    assert.deepEqual(create2dArray([ 1, 2, 3, 4 ], 4.1) //floats too.
+      , [ [ 1, 2, 3, 4 ] ])
+
+  })
+
 })


### PR DESCRIPTION
- Better failing: parameter 'n' is required to be a number, a float, or a string
  representing just one number or else the program returns an empty array.
  The old 2dArray would stall and lead to a node crash.
- Falsy values in input arrays are ok! Arrays like [0,'',undefined,null] will be processed
  as normal, instead of just straight up not working.
- 'ignore' option: filters out the specified object from the array, leaving the rows in tact. For  example the array [1,2,3, 4] with "ignore = 2" => [ [1], [3,4] ].
- update to the devDepedencies. Some options in jscrc in particular were out of date.

I originally worked on this because your program did this [0,0,0] => [] instead of [0,0,0] => [ [0,0,0] ].

npm run prepublish

```
> 2d-array@0.0.1 prepublish /Users/tbro/dev/2d-array
> npm test && npm prune


> 2d-array@0.0.1 pretest /Users/tbro/dev/2d-array
> npm run-script lint && npm run-script checkStyle


> 2d-array@0.0.1 lint /Users/tbro/dev/2d-array
> jshint .


> 2d-array@0.0.1 checkStyle /Users/tbro/dev/2d-array
> jscs .


> 2d-array@0.0.1 test /Users/tbro/dev/2d-array
> istanbul cover ./node_modules/.bin/_mocha test



  2d-array
    ✓ should transform a 1d array into a 2d array
    ✓ should transform a 1d array with falsy values into a 2d array
    ✓ should allow set values to be ignored
    ✓ should return an empty array when n is not a number


  4 passing (10ms)

=============================================================================
Writing coverage object [/Users/tbro/dev/2d-array/coverage/coverage.json]
Writing coverage reports at [/Users/tbro/dev/2d-array/coverage]
=============================================================================

=============================== Coverage summary ===============================
Statements   : 100% ( 13/13 )
Branches     : 100% ( 6/6 )
Functions    : 100% ( 4/4 )
Lines        : 100% ( 13/13 )
================================================================================

> 2d-array@0.0.1 posttest /Users/tbro/dev/2d-array
> istanbul check-coverage && rm -rf coverage
```
